### PR TITLE
Have -pl only complete maven projects

### DIFF
--- a/bash_completion.bash
+++ b/bash_completion.bash
@@ -49,7 +49,7 @@ __ltrim_colon_completions()
 function_exists __find_mvn_projects ||
 __find_mvn_projects()
 {
-    find -name 'pom.xml' -not -path '*/target/*' -prune | while read LINE ; do
+    find . -name 'pom.xml' -not -path '*/target/*' -prune | while read LINE ; do
         local withoutPom=${LINE%/pom.xml}
         local module=${withoutPom#./}
         if [[ -z ${module} ]]; then


### PR DESCRIPTION
This makes the completions for `-pl` cleverer, so it will only give completions for directories which are actually Maven modules (as indicated by the presence of a `pom.xml`).

It will also provide completions for modules which are several levels deep in the hierarchy, which has the nice effect of not considering `parent-module,` to be a valid completion when there's a module `parent-module/child-module` (you'll still get offered `parent-module`, i.e. without the trailing comma in this case, which makes it easier to type `/` to continue getting completions for submodules).

Informal timing numbers for `__find_mvn_projects` on some Atlassian code bases:
- JIRA (98 modules / 84477 files): ~0.150s
- Confluence (143 modules / 53855 files): ~0.100s
- Crowd (75 modules / 19219 files): ~0.050s

These numbers seem reasonable to me; you do notice a bit of a delay, but it's not a huge deal. This could be improved slightly when completing child module names by making `__find_mvn_projects` take `cur` into account so `find` starts its search in the already-typed-out parent module, but I figure that's something for a later pull request.

I did try an alternate approach using bash's [globstar](http://www.gnu.org/software/bash/manual/html_node/The-Shopt-Builtin.html) but performance was ~2-3x worse than using find, plus `globstar` was only added in bash 4 so `find` seems more portable to me.
