### PR TITLE
Add installation instructions for MacOS X/Homebrew

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,11 @@ An example install as a one-line command line call for Debian and other distro i
 
 `sudo wget https://raw.github.com/juven/maven-bash-completion/master/bash_completion.bash --output-document /etc/bash_completion.d/mvn`
 
+Example install for MacOS X using the [Homebrew](http://brew.sh/) package manager:
+
+1. `brew tap homebrew/completion` (add Git repository with completions to list of formulae, if not already done)
+2. `brew install maven-completion` (install maven-completion formula)
+
 ## Usage
 
 To list common lifecycle phases:  


### PR DESCRIPTION
I recently created a [formula for the Homebrew package manager](https://github.com/Homebrew/homebrew-completions/blob/master/maven-completion.rb) to allow easy installation of the maven-bash-completion on MacOS X. Would be nice if you could include the installation instructions in the README file, so that Mac users are aware of the easy installation method. Feel free to adapt the wording as you see fit...
