### PR TITLE
helper alias

### DIFF
--- a/bash_completion.bash
+++ b/bash_completion.bash
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 function_exists()
 {
 	declare -F $1 > /dev/null

--- a/bash_completion.bash
+++ b/bash_completion.bash
@@ -258,7 +258,7 @@ function _maven_quiet {
    if tty -s <&1
    then
       OUTPUT_LINES=$(echo "$OUTPUT" | wc -l)
-      if [ $OUTPUT_LINES > $SCREEN_LINES ]
+      if [ $OUTPUT_LINES -gt $SCREEN_LINES ]
       then
          echo "$OUTPUT" | less
       else
@@ -271,5 +271,12 @@ function _maven_quiet {
 
 alias mvn=_maven_quiet
 
+function _maven_help {
+   mvn help:describe -Ddetail -Dcmd=$1
+}
+
+alias mvnh=_maven_help
+
 complete -o default -F _mvn -o nospace mvn
 complete -o default -F _mvn -o nospace mvnDebug
+complete -o default -F _mvn -o nospace mvnh

--- a/bash_completion.bash
+++ b/bash_completion.bash
@@ -249,5 +249,27 @@ _mvn()
     __ltrim_colon_completions "$cur"
 }
 
+function _maven_quiet { 
+   SCREEN_LINES=$(tput lines)
+   SCREEN_WIDTH=$(tput cols)
+   echo
+   #TODO: test first tty
+   OUTPUT=$(/usr/bin/mvn $@ | grep -v "^\[INFO\]" | grep -v "^\[WARNING\]" | sed 's/^\[ERROR\] //' | fold -w $SCREEN_WIDTH)
+   if tty -s <&1
+   then
+      OUTPUT_LINES=$(echo "$OUTPUT" | wc -l)
+      if [ $OUTPUT_LINES > $SCREEN_LINES ]
+      then
+         echo "$OUTPUT" | less
+      else
+         echo "$OUTPUT"
+      fi
+   else
+      echo "$OUTPUT"
+   fi
+}
+
+alias mvn=_maven_quiet
+
 complete -o default -F _mvn -o nospace mvn
 complete -o default -F _mvn -o nospace mvnDebug


### PR DESCRIPTION
Although q&d, consider this concepts to ease use of maven from commandline
- filter noisy mvn output: Remove [INFO], [WARNING] lines and  [ERROR] prefix. invoke `less` when neccesary 
- add mvn help command: easy check for avaliable options in maven
