### PR TITLE
Add jetty:run-forked

### DIFF
--- a/bash_completion.bash
+++ b/bash_completion.bash
@@ -160,7 +160,7 @@ _mvn()
     local plugin_goals_javadoc="javadoc:javadoc|javadoc:jar|javadoc:aggregate"
     local plugin_goals_jboss="jboss:start|jboss:stop|jboss:deploy|jboss:undeploy|jboss:redeploy"
     local plugin_goals_jboss_as="jboss-as:add-resource|jboss-as:deploy|jboss-as:deploy-only|jboss-as:deploy-artifact|jboss-as:redeploy|jboss-as:redeploy-only|jboss-as:undeploy|jboss-as:undeploy-artifact|jboss-as:run|jboss-as:start|jboss-as:shutdown|jboss-as:execute-commands"
-    local plugin_goals_jetty="jetty:run|jetty:run-exploded"
+    local plugin_goals_jetty="jetty:run|jetty:run-exploded|jetty:run-forked"
     local plugin_goals_jxr="jxr:jxr"
     local plugin_goals_license="license:format|license:check"
     local plugin_goals_liquibase="liquibase:changelogSync|liquibase:changelogSyncSQL|liquibase:clearCheckSums|liquibase:dbDoc|liquibase:diff|liquibase:dropAll|liquibase:help|liquibase:migrate|liquibase:listLocks|liquibase:migrateSQL|liquibase:releaseLocks|liquibase:rollback|liquibase:rollbackSQL|liquibase:status|liquibase:tag|liquibase:update|liquibase:updateSQL|liquibase:updateTestingRollback"


### PR DESCRIPTION
Only manually tested locally on OSX 10.11.4 and Vagrant with Ubuntu 15.10. Will fix #75 