### PR TITLE
Adding rest of Jetty commands

### DIFF
--- a/bash_completion.bash
+++ b/bash_completion.bash
@@ -160,7 +160,7 @@ _mvn()
     local plugin_goals_javadoc="javadoc:javadoc|javadoc:jar|javadoc:aggregate"
     local plugin_goals_jboss="jboss:start|jboss:stop|jboss:deploy|jboss:undeploy|jboss:redeploy"
     local plugin_goals_jboss_as="jboss-as:add-resource|jboss-as:deploy|jboss-as:deploy-only|jboss-as:deploy-artifact|jboss-as:redeploy|jboss-as:redeploy-only|jboss-as:undeploy|jboss-as:undeploy-artifact|jboss-as:run|jboss-as:start|jboss-as:shutdown|jboss-as:execute-commands"
-    local plugin_goals_jetty="jetty:run|jetty:run-exploded|jetty:run-forked"
+    local plugin_goals_jetty="jetty:run|jetty:run-war|jetty:run-exploded|jetty:deploy-war|jetty:run-forked|jetty:start|jetty:stop|jetty:effective-web-xml"
     local plugin_goals_jxr="jxr:jxr"
     local plugin_goals_license="license:format|license:check"
     local plugin_goals_liquibase="liquibase:changelogSync|liquibase:changelogSyncSQL|liquibase:clearCheckSums|liquibase:dbDoc|liquibase:diff|liquibase:dropAll|liquibase:help|liquibase:migrate|liquibase:listLocks|liquibase:migrateSQL|liquibase:releaseLocks|liquibase:rollback|liquibase:rollbackSQL|liquibase:status|liquibase:tag|liquibase:update|liquibase:updateSQL|liquibase:updateTestingRollback"


### PR DESCRIPTION
I noticed the comment in #76 from @bakulinav . This pull requests adds:
- jetty:run-war
- jetty:deploy-war
- jetty:start
- jetty:stop
- jetty:effective-web-xml

This seems to complete the set as described on http://www.eclipse.org/jetty/documentation/current/jetty-maven-plugin.html
