### PR TITLE
Extracting profiles

### DIFF
--- a/bash_completion.bash
+++ b/bash_completion.bash
@@ -196,7 +196,7 @@ _mvn()
     local profiles="${profile_settings}|"
     for item in ${POM_HIERARCHY[*]}
     do
-        local profile_pom=`[ -e $item ] && grep -e "<profile>" -A 1 $item | grep -e "<id>.*</id>" | sed 's/.*<id>//' | sed 's/<\/id>.*//g' | tr '\n' '|' `
+        local profile_pom=`[ -e $item ] && grep -e "<profile>" -A 1000 $item | grep --before-context=1000 '</profiles>' | grep -e "<id>.*</id>" | sed 's/.*<id>//' | sed 's/<\/id>.*//g' | tr '\n' '|' `
         local profiles="${profiles}|${profile_pom}"
     done
 

--- a/bash_completion.bash
+++ b/bash_completion.bash
@@ -110,6 +110,8 @@ __pom_hierarchy()
         fi
     	POM_HIERARCHY+=("$pom")
     done
+    # Include also any pom from modules
+    for pom in $(find -mindepth 2 -name pom.xml); do POM_HIERARCHY+=("$pom"); done
 }
 
 _mvn()


### PR DESCRIPTION
Improvements / fixes:
1. When reading profiles from pom.xml, if the `<id>` element within `<profile>` is not in the first line after `<profile>` then it was not read at all. I have changed this so profile reading is more robust and `<id>` can be in any line within the profile element. It is still more of a workaround rather than proper parsing of XML file but it does the job.
2. When the root pom.xml has some modules, their poms are included too. For example, profiles can be specified in a module only and they are not read if only root pom is parsed.
