### PR TITLE
Use "builtin cd" instead of just "cd"

### DIFF
--- a/bash_completion.bash
+++ b/bash_completion.bash
@@ -66,13 +66,13 @@ _realpath ()
     if [[ -f "$1" ]]
     then
         # file *must* exist
-        if cd "$(echo "${1%/*}")" &>/dev/null
+        if builtin cd "$(echo "${1%/*}")" &>/dev/null
         then
 	    # file *may* not be local
 	    # exception is ./file.ext
 	    # try 'cd .; cd -;' *works!*
  	    local tmppwd="$PWD"
-	    cd - &>/dev/null
+	    builtin cd - &>/dev/null
         else
 	    # file *must* be local
 	    local tmppwd="$PWD"


### PR DESCRIPTION
Similar to https://github.com/juven/maven-bash-completion/pull/68

In case someone has overloaded the "cd" command (with alias), the
plugin's behaviour can be odd. E.g. if a cd alias also types in "ls"
after "cd", the autocompletion will spew out directory contents each
time user hits tab.

This MR amends said problem by ensuring cd is default version.